### PR TITLE
cmd: Make 'to_base64' accept hex values with '0x' prefix

### DIFF
--- a/cmd/to_base64/main.go
+++ b/cmd/to_base64/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/streamingfast/tooling/cli"
 )
@@ -17,7 +18,12 @@ func main() {
 
 func toBase64(element string) string {
 	if cli.HexRegexp.MatchString(element) {
+		if strings.HasPrefix(element, "0x") {
+			element = element[2:]
+		}
+
 		bytes, err := hex.DecodeString(element)
+
 		cli.NoError(err, "invalid hex value %q", element)
 
 		return base64.StdEncoding.EncodeToString(bytes)


### PR DESCRIPTION
Before:

```
$ to_base64 1234
EjQ=

$ to_base64 0x1234
invalid hex value "0x1234": encoding/hex: invalid byte: U+0078 'x'
```

Now:

```
$ to_base64 1234
EjQ=

$ to_base64 0x1234
EjQ=
```

🎉 