### PR TITLE
better time print

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -509,6 +509,9 @@ var layouts = []string{
 	// Found in `zap-pretty` output
 	"2006-01-02 15:04:05.999999999 MST",
 
+	// Found in some GST/timezone-between-date-and-time format (e.g. "2026-04-20 GST 02:58:03.15")
+	"2006-01-02 MST 15:04:05.999999999",
+
 	// Found in some Telegram data reporting
 	"2006-01-02 15:04:05UTC",
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 var testLocation = time.FixedZone("EST", -5*60*60)
+var edtLocation = time.FixedZone("EDT", -4*60*60)
 
 func init() {
 	timeNow = func() time.Time {
-		return time.Unix(1732886907, 718000000)
+		return time.Unix(1732886907, 718000000).UTC()
 	}
 }
 
@@ -28,7 +29,7 @@ func Test_ParseDateLikeInput(t *testing.T) {
 	}{
 		{
 			"now",
-			want{date(t, "2024-11-29 08:28:27.718-05:00"), DateParsedFromLayout, true},
+			want{date(t, "2024-11-29 13:28:27.718Z"), DateParsedFromLayout, true},
 		},
 		{
 			"2023-04-13T14:25:27.180-0400",
@@ -58,7 +59,7 @@ func Test_ParseDateLikeInput(t *testing.T) {
 		{
 			// Found `zap-pretty` output
 			"2024-07-23 14:37:10.304 EDT",
-			want{date(t, "2024-07-23 14:37:10.304-04:00"), DateParsedFromLayout, true},
+			want{dateAtLocation(t, "2024-07-23 14:37:10.304", edtLocation), DateParsedFromLayout, true},
 		},
 		{
 			// Found in some Telegram date reporting

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -95,6 +95,21 @@ func Test_ParseDateLikeInput(t *testing.T) {
 			"2025-04-02 16:00:00 UTC",
 			want{dateAtLocation(t, "2025-04-02 16:00:00", time.UTC), DateParsedFromLayout, true},
 		},
+		{
+			// Hardfork timestamp format midnight UTC (shifts to previous day in local)
+			"2026-04-13 00:00:00 UTC",
+			want{dateAtLocation(t, "2026-04-13 00:00:00", time.UTC), DateParsedFromLayout, true},
+		},
+		{
+			// Hardfork timestamp early morning UTC (shifts to previous day in local)
+			"2026-04-28 02:30:00 UTC",
+			want{dateAtLocation(t, "2026-04-28 02:30:00", time.UTC), DateParsedFromLayout, true},
+		},
+		{
+			// Hardfork timestamp afternoon UTC
+			"2026-03-19 14:30:00 UTC",
+			want{dateAtLocation(t, "2026-03-19 14:30:00", time.UTC), DateParsedFromLayout, true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.element, func(t *testing.T) {

--- a/cmd/to_date/main.go
+++ b/cmd/to_date/main.go
@@ -11,6 +11,7 @@ import (
 var asUnixSecondsFlag = flag.Bool("s", false, "Avoid heuristics based to determine decimal range value and assume it's UNIX seconds since epoch")
 var asUnixMillisFlag = flag.Bool("ms", false, "Avoid heuristics based to determine decimal range value and assume it's UNIX milliseconds since epoch")
 var timezoneFlag = flag.String("timezone", "local", "When the provided date is not timezone aware, use this timezone to interpret it. Valid values are 'local', 'utc', 'z' or a valid timezone name.")
+var localFlag = flag.Bool("l", false, "Output human-readable local time alongside UTC")
 
 func main() {
 	flag.Parse()
@@ -31,7 +32,11 @@ func main() {
 	}
 
 	if count == 0 {
-		fmt.Println(formatDate(time.Now()))
+		if *localFlag {
+			fmt.Println(formatLocalDate(time.Now()))
+		} else {
+			fmt.Println(formatDate(time.Now()))
+		}
 	}
 }
 
@@ -49,16 +54,33 @@ func toDate(element string, timezoneIfUnset *time.Location) (out string) {
 		hint = cli.DateLikeHintUnixSeconds
 	}
 
-	if *asUnixSecondsFlag {
-		hint = cli.DateLikeHintUnixSeconds
-	}
-
 	parsed, _, ok := cli.ParseDateLikeInput(element, hint, timezoneIfUnset)
 	if !ok {
 		return fmt.Sprintf("Unable to interpret %q", element)
 	}
 
+	if *localFlag {
+		return formatLocalDate(parsed)
+	}
+
 	return formatDate(parsed)
+}
+
+func formatLocalDate(in time.Time) string {
+	loc := in.Local()
+	utc := in.UTC()
+	_, offset := loc.Zone()
+	offsetHours := offset / 3600
+	sign := "+"
+	if offsetHours < 0 {
+		sign = "-"
+		offsetHours = -offsetHours
+	}
+	return fmt.Sprintf("UTC:   %s\nLocal: %s  (UTC%s%d)",
+		utc.Format("2006/01/02  15:04:05"),
+		loc.Format("2006/01/02  15:04:05"),
+		sign, offsetHours,
+	)
 }
 
 func formatDate(in time.Time) string {


### PR DESCRIPTION
output to visualize hardfork time better:

```bash
ulyssecorbeil@Ulysses-MacBook-Pro  ~/Documents/SF/tooling   master ±  to_date -l "2026-04-13 00:00:00 UTC"
UTC:   2026/04/13  00:00:00
Local: 2026/04/12  20:00:00  (UTC-4)

ulyssecorbeil@Ulysses-MacBook-Pro  ~/Documents/SF/tooling   master ±  to_date -l "2026-03-19 00:14:30 UTC"
UTC:   2026/03/19  00:14:30
Local: 2026/03/18  20:14:30  (UTC-4)

ulyssecorbeil@Ulysses-MacBook-Pro  ~/Documents/SF/tooling   master ±  to_date -l "2026-04-28 02:30:00 AM UTC"
UTC:   2026/04/28  02:30:00
Local: 2026/04/27  22:30:00  (UTC-4)
```